### PR TITLE
Add column support

### DIFF
--- a/template/lib.typ
+++ b/template/lib.typ
@@ -138,17 +138,24 @@
 #let main_heading(x) = {
   pagebreak(weak: true)
 
-  set text(font: "TeX Gyre Heros", size: 20pt, stretch: 85%)
-  set block(spacing: 0pt)
-  v(75pt)
-  if x.numbering == none {
-    align(end, x.body)
-  } else {
-    align(left, x)
-  }
-  v(13pt)
-  line(length: 100%, stroke: (paint: gray, thickness: 3.5pt))
-  v(50pt)
+  place(
+    top + left,
+    scope: "parent",
+    float: true,
+    {
+      set text(font: "TeX Gyre Heros", size: 20pt, stretch: 85%)
+      set block(spacing: 0pt)
+      v(75pt)
+      if x.numbering == none {
+        align(end, x.body)
+      } else {
+        align(left, x)
+      }
+      v(13pt)
+      line(length: 100%, stroke: (paint: gray, thickness: 3.5pt))
+      v(27pt)
+    },
+  )
 }
 
 #let court_info(


### PR DESCRIPTION
This PR changes main headings so they are `place`d on page scope instead of column scope, making them as wide as the entire page even if `#set page(columns: 2)` is used.

Without columns:
![Screenshot_20250226_122328](https://github.com/user-attachments/assets/4fe73dac-01a2-4597-8523-9cd88b486a6d)

With columns:
![Screenshot_20250226_122229](https://github.com/user-attachments/assets/9e13805e-3726-46aa-9a06-0127498e6cd5)

I'm still not entirely convinced this looks good in this context nor if we even are allowed to use it for an official document, but this change doesn't affect non-column users at all, so it's an absolute plus for the template's flexibility.