### PR TITLE
Show headings on a new page

### DIFF
--- a/template/lib.typ
+++ b/template/lib.typ
@@ -136,7 +136,11 @@
 }
 
 #let main_heading(x) = {
-  pagebreak(weak: true)
+  // Show the heading on a new page, on the front side. Ignore the header if we create any empty pages
+  {
+    set page(header: none)
+    pagebreak(weak: true, to: "odd")
+  }
 
   place(
     top + left,


### PR DESCRIPTION
Shows level 1 headings on a completely new page, so that when the document is printed all main headings display on the front. For instance:
![Screenshot_20250314_134823](https://github.com/user-attachments/assets/84f02fd0-a3b6-4efd-ba12-0e90d5a8b5f0)
