### PR TITLE
Fix entry name appearing on subsequent page

### DIFF
--- a/template/lib.typ
+++ b/template/lib.typ
@@ -242,6 +242,9 @@
 
     // Data representation
 
+    // Show the section number, page number and entry name on the same page
+    set block(breakable: false)
+    
     // The first 'if' is for elements that have levels, i.e. headings
     if item.at("level", default: none) != none {
       let entry = [#grid(


### PR DESCRIPTION
If an entry on the index is too long, it will break onto the next page like this, leaving the page & section number behind:
![Screenshot_20250314_135211](https://github.com/user-attachments/assets/8de3ec11-6d38-4890-9502-2e26c41b3e39)

This PR fixes the issue:
![Screenshot_20250314_135544](https://github.com/user-attachments/assets/e506d77e-37c7-480c-889d-ee5241581fe1)
