### PR TITLE
Ignore index title if equal to `none`

### DIFF
--- a/template/lib.typ
+++ b/template/lib.typ
@@ -210,7 +210,9 @@
 
 
 #let index(title: [Índice], target: heading) = context {
-  [= #title]
+  if title != none {
+    [= #title]
+  }
 
   set text(font: "TeX Gyre Heros", size: 12pt, stretch: 85%)
 


### PR DESCRIPTION
Allows passing `none` to the `title` parameter of `index` to not include a title. Useful for concatenating different index targets (e.g. figures, then tables, then equations)